### PR TITLE
Add bindings to manually notify watchdog

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+examples/

--- a/README.md
+++ b/README.md
@@ -113,6 +113,26 @@ app.listen(PORT, () => {
 
 ...this way the Node process will behave in the correct manner in either situation.
 
+__Manual keep alive:__
+```javasript
+
+app.listen(PORT, () => {
+  console.log('listening on port ' + PORT)
+  notify.ready()
+
+  const watchdogInterval = notify.watchdogInterval()
+
+  if (watchdogInterval > 0) {
+    const interval = Math.floor(watchdogInterval / 2)
+    const intervalId = setInterval(() => {
+      if(!isDeadlockDetected()) {
+        notify.watchdogKeepAlive()
+      }
+    }, interval)
+  }
+})
+```
+
 __Status:__
 
 You can also send some status string to __systemd__, which will append to the service's log.

--- a/index.js
+++ b/index.js
@@ -52,6 +52,10 @@ module.exports = Object.assign({}, sdNotify, {
     }
   },
 
+  watchdogKeepAlive: () => {
+    sdNotify.watchdog()
+  },
+
   sendStatus: (text) => {
     sdNotify.sendState('STATUS=' + text + '\n')
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "install": "node-gyp rebuild"
   },
   "gypfile": true,
-  "name": "sd-notify",
+  "name": "@connectedcars/sd-notify",
   "description": "wrapper around sd_notify for using systemd as a node process manager",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
It seems that the current bindings dont really add much benefit of actually interacting with a watchdog. I recon that it should be possible to uphold the signal manually, and tie this directly to liveness signals and assertions from different modules in your application.