### PR TITLE
Add noop support for win32

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "os": [
     "linux",
-    "darwin"
+    "darwin",
+    "win32"
   ],
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
Just as macOS has "support" via a no-op file, it would be nice to do the same for Windows platforms.